### PR TITLE
Fix download list for collections with hidden items, add `--include-hidden`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ downloaded if the sizes differ. Otherwise already existing albums will not be
 re-downloaded.
 
 positional arguments:
-  username              Your bandcamp username
+  username              Your bandcamp username, as it appears at the end of
+                        your bandcamp collection url, I.E. bandcamp.com/user_name
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -110,7 +111,7 @@ optional arguments:
                         '{artist}/{artist} - {title}'.
                         All placeholders: item_id, artist, title
   --format {aac-hi,aiff-lossless,alac,flac,mp3-320,mp3-v0,vorbis,wav}, -f {aac-hi,aiff-lossless,alac,flac,mp3-320,mp3-v0,vorbis,wav}
-                        What format do download the songs in. Default is
+                        What format to download the songs in. Default is
                         'mp3-320'.
   --parallel-downloads PARALLEL_DOWNLOADS, -p PARALLEL_DOWNLOADS
                         How many threads to use for parallel downloads. Set to
@@ -144,7 +145,7 @@ When modifying required packages, please:
 
 If you have a logged in session in the browser, have used the `--browser`/`-b` flag correctly, and still are being told that the script isn't finding any albums, check out the page for [browser_cookie3](https://github.com/borisbabic/browser_cookie3), you might need to do some configuring in your browser to make the cookies available to the script.
 
-Similarly, if you have installed your browser via a flatpack the cookies will not be in the default location. You can work around this by either using `--cookies` to specify the path or create a symlink to where the browser would normally have it's config directory be.
+Similarly, if you have installed your browser via a flatpack the cookies will not be in the default location. You can work around this by either using `--cookies` to specify the path or create a symlink to where the browser would normally have its config directory be.
 
 If you are downloading your collection in multiple formats, the script can't tell if an already downloaded zip file is the same format or not, and will happily overwrite it. So make sure to use different directories for different formats, either by running the script somewhere else or by supplying directories to the `--directory`/`-d` flag.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Alternatively, you can use a [Netscape format cookies](https://curl.se/docs/http
 
 Albums will be downloaded into their zip files and singles will just be plain files. Downloads are organized by Artist name. Already existing files of the same name will have their file sizes checked against what it should be, and if they are the same, the download will be skipped, otherwise it will be over-written. You can use the `--force` flag to always overwrite existing files.
 
+By default the download only includes unhidden items in your collection. To include hidden items as well, use the `--include-hidden` flag.
+
 Downloads will happen in parallel, by default using a pool of 5 threads. You can configure how many threads to use with the `--parallel-downloads`/`-p` flag. After each download a thread will wait 1 second before trying the next download. This is to try and not overwhelm (and be rejected by) the bandcamp servers. This can be configured with the `--wait-after-download` flag.
 
 If a download should fail because of an HTTP/network error, it will be retried again after a short wait. By default a file download will be attempted at most 5 times. This can be configured with the `--max-download-attempts` flag. By default, a failed download will wait 5 seconds before trying again. This can be configured by the `--retry-wait` flag.

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -171,6 +171,14 @@ def main() -> int:
     print('Done.')
 
 def generate_collection_post_payload(_user_info : dict) -> None:
+    # The number of items we still need is:
+    #   _user_info['collection_count'] - len(_user_info['download_urls']
+    # Unfortunately the post request includes hidden items, which will
+    # count against our request length but will not give us one of the
+    # download urls we need.
+    # Because of this we request somewhat more than we actually need,
+    # and check more_available in the response in case it still isn't enough.
+    count = _user_info['collection_count'] - len(_user_info['download_urls']) + 50
     return {
         'fan_id' : _user_info['user_id'],
         'count' : _user_info['collection_count'] - len(_user_info['download_urls']),
@@ -178,16 +186,34 @@ def generate_collection_post_payload(_user_info : dict) -> None:
     }
 
 def get_user_collection(_user_info : dict) -> None:
-    with requests.post(
-        COLLECTION_POST_URL,
-        data = json.dumps(generate_collection_post_payload(_user_info)),
-        cookies = get_cookies(),
-    ) as response:
-        response.raise_for_status()
-        data = json.loads(response.text)
-        _user_info['download_urls'] += data['redownload_urls'].values()
+    #last_token = "{}::a::".format(int(time.time()))
+    # start with the last token from the initial page of results
+    last_token = _user_info['last_token']
+    more_available = True
+    while more_available:
+        payload = generate_collection_post_payload(_user_info, last_token)
+        with requests.post(
+            COLLECTION_POST_URL,
+            data = json.dumps(payload),
+            cookies = get_cookies(),
+        ) as response:
+            response.raise_for_status()
+            data = json.loads(response.text)
+            _user_info['download_urls'] += data['redownload_urls'].values()
+            last_token = data['last_token']
+            more_available = data['more_available']
 
 def get_download_links_for_user(_user : str) -> [str]:
+    url = {"fan_id":184803,"older_than_token":"1697579887:773608077:a::","count":1000}
+    result = requests.post(
+        "https://bandcamp.com/api/fancollection/1/collection_items",
+        data={
+            "fan_id":184803,
+            "older_than_token":"1697579887:773608077:a::",
+            "count":1000
+        },
+                           data: _Data | None = None, json: Incomplete | None = None, *, params: _Params | None = ..., headers: _HeadersMapping | None = ..., cookies: RequestsCookieJar | _TextMapping | None = ..., files: _Files | None = ..., auth: _Auth | None = ..., timeout: _Timeout | None = ..., allow_redirects: bool = ..., proxies: _TextMapping | None = ..., hooks: _HooksInput | None = ..., stream: bool | None = ..., verify: _Verify | None = ..., cert: _Cert | None = ...) -> Response
+)
     print('Retrieving album links from user [{}]\'s collection.'.format(_user))
 
     soup = BeautifulSoup(

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -174,6 +174,21 @@ def main() -> int:
     CONFIG['TQDM'].close()
     print('Done.')
 
+def fetch_items(_url : str, _user_id : str, _last_token : str, _count : int) -> [str]:
+    payload = {
+        'fan_id' : _user_id,
+        'count' : _count,
+        'older_than_token' : _last_token,
+    }
+    with requests.post(
+        _url,
+        data = json.dumps(payload),
+        cookies = get_cookies(),
+    ) as response:
+        response.raise_for_status()
+        data = json.loads(response.text)
+        return data['redownload_urls'].values()
+
 def get_download_links_for_user(_user : str, include_hidden : bool) -> [str]:
     print('Retrieving album links from user [{}]\'s collection.'.format(_user))
 
@@ -228,21 +243,6 @@ def get_download_links_for_user(_user : str, include_hidden : bool) -> [str]:
             data['hidden_data']['item_count'] - len(data['item_cache']['hidden'])))
         
     return download_urls
-
-def fetch_items(_url : str, _user_id : str, _last_token : str, _count : int) -> [str]:
-    payload = {
-        'fan_id' : _user_id,
-        'count' : _count,
-        'older_than_token' : _last_token,
-    }
-    with requests.post(
-        _url,
-        data = json.dumps(payload),
-        cookies = get_cookies(),
-    ) as response:
-        response.raise_for_status()
-        data = json.loads(response.text)
-        return data['redownload_urls'].values()
 
 def download_album(_album_url : str, _attempt : int = 1) -> None:
     try:

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -64,7 +64,7 @@ TRACK_INFO_KEYS = [
 
 def main() -> int:
     parser = argparse.ArgumentParser(description = 'Download your collection from bandcamp. Requires a logged in session in a supported browser so that the browser cookies can be used to authenticate with bandcamp. Albums are saved into directories named after their artist. Already existing albums will have their file size compared to what is expected and re-downloaded if the sizes differ. Otherwise already existing albums will not be re-downloaded.')
-    parser.add_argument('username', type=str, help='Your bandcamp username')
+    parser.add_argument('username', type=str, help='Your bandcamp username, as it appears at the end of your bandcamp collection url, I.E. bandcamp.com/user_name')
     parser.add_argument(
         '--browser', '-b',
         type=str,
@@ -87,7 +87,7 @@ def main() -> int:
         '--format', '-f',
         default = 'mp3-320',
         choices = SUPPORTED_FILE_FORMATS,
-        help = 'What format do download the songs in. Default is \'mp3-320\'.'
+        help = 'What format to download the songs in. Default is \'mp3-320\'.'
     )
     parser.add_argument(
         '--parallel-downloads', '-p',
@@ -203,6 +203,11 @@ def get_download_links_for_user(_user : str) -> [str]:
         print('ERROR: No div with pagedata found for user at url [{}]'.format(USER_URL.format(_user)))
         return
     data = json.loads(html.unescape(div.get('data-blob')))
+    if 'collection_count' not in data:
+        print('ERROR: No collection info for user {}.\nPlease double check that your given username is correct.\nIt should be given exactly as it appears at the end of your bandcamp user url.\nFor example: bandcamp.com/user_name'.format(
+            _user
+        ))
+        exit(2)
 
     user_info = {
         'collection_count' : data['collection_count'],

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -173,10 +173,10 @@ def main() -> int:
 def generate_collection_post_payload(_user_info : dict) -> None:
     # The number of items we still need is:
     #   _user_info['collection_count'] - len(_user_info['download_urls']
-    # Unfortunately the post request includes hidden items, which will
+    # Unfortunately this post request returns hidden items, which will
     # count against our request length but will not give us one of the
     # download urls we need.
-    # Because of this we request somewhat more than we actually need,
+    # Because of this we make count somewhat higher than our real target,
     # and check more_available in the response in case it still isn't enough.
     count = _user_info['collection_count'] - len(_user_info['download_urls']) + 50
     return {
@@ -204,16 +204,6 @@ def get_user_collection(_user_info : dict) -> None:
             more_available = data['more_available']
 
 def get_download_links_for_user(_user : str) -> [str]:
-    url = {"fan_id":184803,"older_than_token":"1697579887:773608077:a::","count":1000}
-    result = requests.post(
-        "https://bandcamp.com/api/fancollection/1/collection_items",
-        data={
-            "fan_id":184803,
-            "older_than_token":"1697579887:773608077:a::",
-            "count":1000
-        },
-                           data: _Data | None = None, json: Incomplete | None = None, *, params: _Params | None = ..., headers: _HeadersMapping | None = ..., cookies: RequestsCookieJar | _TextMapping | None = ..., files: _Files | None = ..., auth: _Auth | None = ..., timeout: _Timeout | None = ..., allow_redirects: bool = ..., proxies: _TextMapping | None = ..., hooks: _HooksInput | None = ..., stream: bool | None = ..., verify: _Verify | None = ..., cert: _Cert | None = ...) -> Response
-)
     print('Retrieving album links from user [{}]\'s collection.'.format(_user))
 
     soup = BeautifulSoup(

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -225,13 +225,31 @@ def get_download_links_for_user(_user : str) -> [str]:
         ))
         exit(2)
 
-    user_info = {
-        'collection_count' : data['collection_count'],
-        'user_id' : data['fan_data']['fan_id'],
-        'last_token' : data['collection_data']['last_token'],
-    }
-    user_info['download_urls'] = [ *data['collection_data']['redownload_urls'].values() ]
+    redownload = data['collection_data']['redownload_urls']
+    keys = redownload.keys()
+    values = [redownload[key] for key in keys]
 
+    print(values)
+    exit(1)
+    #data['hidden_data']['last_token']
+
+    user_info = {
+        'user_id' : data['fan_data']['fan_id'],
+        'collection' : {
+            'download_urls' : data['collection_data']['redownload_urls'].values(),
+            'count' : data['collection_count'] - len(data['item_cache']['collection']),
+            'last_token' : data['collection_data']['last_token']
+        },
+        'hidden' : {
+            'download_urls' : data['hidden_data']['download_urls'].values(),
+            'count' : data['hidden_count'] - len(data['item_cache']['hidden']),
+            'last_token' : data['hidden_data']['last_token']
+        }
+    }
+    #user_info['download_urls'] = [ *data['collection_data']['redownload_urls'].values() ]
+
+    print(f"{user_info}")
+    exit(1)
     get_user_collection(user_info)
     return user_info['download_urls']
 

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -119,6 +119,12 @@ def main() -> int:
         default = 5,
         help = 'How long, in seconds, to wait before trying to download a file again after a failure. Defaults to \'5\'.',
     )
+    parser.add_argument(
+        '--dry-run',
+        action = 'store_true',
+        default = False,
+        help = 'Don\'t actually download files, just process all the web data and report what would have been done.',
+    )
     parser.add_argument('--verbose', '-v', action='count', default = 0)
     args = parser.parse_args()
 
@@ -132,6 +138,7 @@ def main() -> int:
     CONFIG['BROWSER'] = args.browser
     CONFIG['FORMAT'] = args.format
     CONFIG['FORCE'] = args.force
+    CONFIG['DRY_RUN'] = args.dry_run
 
     if args.wait_after_download < 0:
         parser.error('--wait-after-download must be at least 0.')
@@ -283,6 +290,8 @@ def download_file(_url : str, _track_info : dict = None, _attempt : int = 1) -> 
                         if CONFIG['VERBOSE'] >= 2: CONFIG['TQDM'].write('Album at [{}] is the wrong size. Expected [{}] but was [{}]. Re-downloading.'.format(file_path, expected_size, actual_size))
 
             if CONFIG['VERBOSE'] >= 2: CONFIG['TQDM'].write('Album being saved to [{}]'.format(file_path))
+            if CONFIG['DRY_RUN']:
+                return
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(file_path, 'wb') as fh:
                 for chunk in response.iter_content(chunk_size=8192):

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -31,7 +31,6 @@ CONFIG = {
     'BROWSER' : None,
     'FORMAT' : None,
     'FORCE' : False,
-    'INCLUDE_HIDDEN': False,
     'TQDM' : None,
     'MAX_URL_ATTEMPTS' : 5,
     'URL_RETRY_WAIT' : 5,
@@ -127,8 +126,13 @@ def main() -> int:
         default = False,
         help = 'Don\'t actually download files, just process all the web data and report what would have been done.',
     )
+    parser.add_argument(
+        '--include-hidden',
+        action='store_true',
+        default=False,
+        help = 'Download items in your collection that have been marked as hidden.',
+    )
     parser.add_argument('--verbose', '-v', action='count', default = 0)
-    parser.add_argument('--include-hidden', action='store_true', default=False)
     args = parser.parse_args()
 
     if args.parallel_downloads < 1 or args.parallel_downloads > MAX_THREADS:
@@ -136,7 +140,6 @@ def main() -> int:
 
     CONFIG['COOKIES'] = args.cookies
     CONFIG['VERBOSE'] = args.verbose
-    CONFIG['INCLUDE_HIDDEN'] = args.include_hidden
     CONFIG['OUTPUT_DIR'] = os.path.normcase(args.directory)
     CONFIG['FILENAME_FORMAT'] = args.filename_format
     CONFIG['BROWSER'] = args.browser
@@ -157,7 +160,7 @@ def main() -> int:
     if CONFIG['VERBOSE']: print(args)
     if CONFIG['FORCE']: print('WARNING: --force flag set, existing files will be overwritten.')
 
-    links = get_download_links_for_user(args.username, CONFIG['INCLUDE_HIDDEN'])
+    links = get_download_links_for_user(args.username, args.include_hidden)
     if CONFIG['VERBOSE']: print('Found [{}] links for [{}]\'s collection.'.format(len(links), args.username))
     if not links:
         print('WARN: No album links found for user [{}]. Are you logged in and have you selected the correct browser to pull cookies from?'.format(args.username))

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -189,7 +189,7 @@ def fetch_items(_url : str, _user_id : str, _last_token : str, _count : int) -> 
         data = json.loads(response.text)
         return data['redownload_urls'].values()
 
-def get_download_links_for_user(_user : str, include_hidden : bool) -> [str]:
+def get_download_links_for_user(_user : str, _include_hidden : bool) -> [str]:
     print('Retrieving album links from user [{}]\'s collection.'.format(_user))
 
     soup = BeautifulSoup(
@@ -218,7 +218,7 @@ def get_download_links_for_user(_user : str, include_hidden : bool) -> [str]:
     # the list... but this is a little uncomfortable to rely on, so let's divide
     # them up by explicitly checking item_cache.
     items = list(data['item_cache']['collection'].values())
-    if include_hidden:
+    if _include_hidden:
         items.extend(data['item_cache']['hidden'].values())
     item_keys = [str(item['sale_item_type']) + str(item['sale_item_id'])
                  for item in items
@@ -235,7 +235,7 @@ def get_download_links_for_user(_user : str, include_hidden : bool) -> [str]:
         # count is the number we have left to fetch after the initial data blob
         data['collection_data']['item_count'] - len(data['item_cache']['collection'])))
     
-    if include_hidden:
+    if _include_hidden:
         download_urls.extend(fetch_items(
             HIDDEN_POST_URL,
             user_id,


### PR DESCRIPTION
When requesting a collection, Bandcamp returns the first page of items in `item_cache.collection` and the first page of hidden items in `item_cache.hidden`. The total number of items in the two categories (across all pages) are `collection_data.item_count` and `hidden_data.item_count`.

We might hope that there would then be `len(item_cache.collection)` entries in `collection_data.redownload_urls`, and `len(item_cache.hidden)` entries in `hidden_data.redownload_urls`. Unfortunately, `hidden_data.redownload_urls` doesn't exist, and instead there are `len(item_cache.collection) + len(item_cache.hidden)` items in `collection_data.redownload_urls`, combining both hidden and unhidden results.

`bandcamp-downloader` calculates the number of items to request by the total length of the (visible) library minus the length of `redownload_urls`:

```py
    'count' : _user_info['collection_count'] - len(_user_info['download_urls']),
```

Because of the page of hidden items in the download urls, this means that for collections with hidden items, one page of hidden items is included in the url list, and one page of unhidden items is truncated from the end of the list.

This PR adds the ability to intentionally include hidden downloads with the `--include-hidden` flag. When false, it skips URLs for hidden items in the initial query, which fixes the issue where some visible items would be missing in the resulting download. When true, it adds a request to the POST endpoint for hidden items, `.../hidden_items`, to fetch the remaining pages (previously only `.../collection_items` was used).

Fixes https://github.com/easlice/bandcamp-downloader/issues/5.