### PR TITLE
Remove immediate return from download_album

### DIFF
--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -291,7 +291,6 @@ def get_download_links_for_user(_user : str, _include_hidden : bool, _since : da
 
 def download_album(_album_url : str, _attempt : int = 1) -> None:
     try:
-        return
         soup = BeautifulSoup(
             requests.get(
                 _album_url,


### PR DESCRIPTION
The start of the function had a return statement preventing the body from executing