### PR TITLE
feat: add --extract flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ usage: bandcamp-downloader.py [-h]
                               [--include-hidden]
                               [--download-since DOWNLOAD_SINCE]
                               [--dry-run]
+                              [--unzip]
                               [--verbose] [-v]
                               username
 
@@ -154,6 +155,9 @@ optional arguments:
                         YYYY-MM-DD format, defaults to all items.
   --dry-run             Don't actually download files, just process all the web data
                         and report what would have been done.
+                        
+  --unzip               Unzip all albums into a subfolder named after the album, under the artist folder.
+                        Deletes the zip file on completion of command.  
   --verbose, -v
 ```
 

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -410,7 +410,7 @@ def download_file(_url : str, _track_info : dict = None, _attempt : int = 1) -> 
 
 def print_exception(_e : Exception, _msg : str = '') -> None:
     CONFIG['TQDM'].write('\nERROR: {}'.format(_msg))
-    CONFIG['TQDM'].write('\n'.join(traceback.format_exception(_e)))
+    CONFIG['TQDM'].write('\n'.join(traceback.format_exception(etype=type(_e), value=_e , tb=_e.__traceback__)))
     CONFIG['TQDM'].write('\n')
 
 

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -217,6 +217,8 @@ def main() -> int:
 
     print('Done.')
 
+    return 0
+
 def filter_by_purchase_time(items : [dict], _since : datetime.datetime) -> [dict]:
     good = []
     for item in items:

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -139,9 +139,11 @@ def main() -> int:
         help = 'Only download items purchased on or after the given date. YYYY-MM-DD format, defaults to all items.'
     )
     parser.add_argument(
-        '--unzip',
+        '--extract', '-x',
         action='store_true',
-        help='Unzip albums after downloading, deleting the zip file.'
+        help='Extracts downloaded albums, organised in {ARTIST}/{ALBUM} subdirectories. Songs are extracted to the '
+             'path specified in the `--directory`/`-d` flag, otherwise to the current directory if not specified. '
+             'Upon completion, original .zip file is deleted.'
     )
     parser.add_argument(
         '--dry-run',
@@ -167,7 +169,7 @@ def main() -> int:
     CONFIG['FORMAT'] = args.format
     CONFIG['FORCE'] = args.force
     CONFIG['DRY_RUN'] = args.dry_run
-    CONFIG['UNZIP'] = args.unzip
+    CONFIG['EXTRACT'] = args.extract
 
     if args.wait_after_download < 0:
         parser.error('--wait-after-download must be at least 0.')
@@ -206,9 +208,9 @@ def main() -> int:
     CONFIG['TQDM'].close()
     downloaded_zips = [zip_file for zip_file in downloaded_zips if zip_file]
     print(downloaded_zips)
-    if args.unzip:
+    if args.extract:
         for zip in downloaded_zips:
-            print(f'unzipping: {zip}')
+            print(f'Extracting compressed archive: {zip}')
             album_name = re.search(r'\- (.+?)\.zip$', zip).group(1)
             extract_dir = os.path.join(os.path.dirname(zip), album_name)
             with zipfile.ZipFile(zip, 'r') as zip_file:

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -193,21 +193,21 @@ def main() -> int:
         sys.exit(2)
 
     print('Starting album downloads...')
+    downloaded_zips = []
     CONFIG['TQDM'] = tqdm(links, unit = 'album')
     if args.parallel_downloads > 1:
         with ThreadPoolExecutor(max_workers = args.parallel_downloads) as executor:
-            executor.map(download_album, links)
+            downloaded_zips = list(executor.map(download_album, links))
     else:
         for link in links:
-            download_album(link)
+            zip_file = download_album(link)
+            if zip_file:
+                downloaded_zips.append(zip_file)
     CONFIG['TQDM'].close()
-
+    downloaded_zips = [zip_file for zip_file in downloaded_zips if zip_file]
+    print(downloaded_zips)
     if args.unzip:
-        base_path = os.getcwd()
-        if args.directory:
-            base_path = args.directory
-        all_zip_files = glob.glob(f'{base_path}/**/*.zip', recursive=True)
-        for zip in all_zip_files:
+        for zip in downloaded_zips:
             print(f'unzipping: {zip}')
             album_name = re.search(r'\- (.+?)\.zip$', zip).group(1)
             extract_dir = os.path.join(os.path.dirname(zip), album_name)
@@ -313,7 +313,7 @@ def get_download_links_for_user(_user : str, _include_hidden : bool, _since : da
 
     return download_urls
 
-def download_album(_album_url : str, _attempt : int = 1) -> None:
+def download_album(_album_url : str, _attempt : int = 1) -> str:
     try:
         soup = BeautifulSoup(
             requests.get(
@@ -341,7 +341,7 @@ def download_album(_album_url : str, _attempt : int = 1) -> None:
 
         download_url = data['download_items'][0]['downloads'][CONFIG['FORMAT']]['url']
         track_info = {key: data['download_items'][0][key] for key in TRACK_INFO_KEYS}
-        download_file(download_url, track_info)
+        return download_file(download_url, track_info)
     except IOError as e:
         if _attempt < CONFIG['MAX_URL_ATTEMPTS']:
             if CONFIG['VERBOSE'] >=2: CONFIG['TQDM'].write('WARN: I/O Error on attempt # [{}] to download the album at [{}]. Trying again...'.format(_attempt, _album_url))
@@ -376,7 +376,6 @@ def download_file(_url : str, _track_info : dict = None, _attempt : int = 1) -> 
             } if _track_info else {}
             filename = CONFIG['FILENAME_FORMAT'].format(**safe_track_info) + extension
             file_path = os.path.join(CONFIG['OUTPUT_DIR'], filename)
-
             if os.path.exists(file_path):
                 if CONFIG['FORCE']:
                     if CONFIG['VERBOSE']: CONFIG['TQDM'].write('--force flag was given. Overwriting existing file at [{}].'.format(file_path))
@@ -384,13 +383,13 @@ def download_file(_url : str, _track_info : dict = None, _attempt : int = 1) -> 
                     actual_size = os.stat(file_path).st_size
                     if expected_size == actual_size:
                         if CONFIG['VERBOSE'] >= 3: CONFIG['TQDM'].write('Skipping album that already exists: [{}]'.format(file_path))
-                        return
+                        return file_path
                     else:
                         if CONFIG['VERBOSE'] >= 2: CONFIG['TQDM'].write('Album at [{}] is the wrong size. Expected [{}] but was [{}]. Re-downloading.'.format(file_path, expected_size, actual_size))
 
             if CONFIG['VERBOSE'] >= 2: CONFIG['TQDM'].write('Album being saved to [{}]'.format(file_path))
             if CONFIG['DRY_RUN']:
-                return
+                return file_path
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(file_path, 'wb') as fh:
                 for chunk in response.iter_content(chunk_size=8192):
@@ -407,6 +406,7 @@ def download_file(_url : str, _track_info : dict = None, _attempt : int = 1) -> 
             print_exception(e, 'An exception occurred trying to download file url [{}]:'.format(_url))
     except Exception as e:
         print_exception(e, 'An exception occurred trying to download file url [{}]:'.format(_url))
+    return file_path
 
 def print_exception(_e : Exception, _msg : str = '') -> None:
     CONFIG['TQDM'].write('\nERROR: {}'.format(_msg))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="bandcamp-downloader",  # Required
-    version="0.1.1",  # Required
+    version="0.1.2",  # Required
     description="Download your collection from Bandcamp.",  # Optional
     long_description=long_description,  # Optional
     long_description_content_type="text/markdown",  # Optional (see note above)


### PR DESCRIPTION
When passed, this extracts all files downloaded by `bandcamp-downloader`. Any other .zip files in the source directory _not_ downloaded by `bandcamp-downloader` will not be extracted.

Extracted files are organised in {ARTIST}/{ALBUM} subdirectories. Songs are extracted to the path specified in the `--directory`/`-d` flag, otherwise to the current directory if not specified.  The album name is derived from the name of the .zip. 

Upon completion, original .zip file is deleted.