### PR TITLE
feat: only extract .zip files

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ usage: bandcamp-downloader.py [-h]
                               [--include-hidden]
                               [--download-since DOWNLOAD_SINCE]
                               [--dry-run]
-                              [--unzip]
+                              [--extract]
                               [--verbose] [-v]
                               username
 
@@ -156,7 +156,7 @@ optional arguments:
   --dry-run             Don't actually download files, just process all the web data
                         and report what would have been done.
                         
-  --unzip               Unzip all albums into a subfolder named after the album, under the artist folder.
+  --extract               Unzip all albums into a subfolder named after the album, under the artist folder.
                         Deletes the zip file on completion of command.  
   --verbose, -v
 ```

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -359,7 +359,8 @@ def download_album(_album_url : str, _attempt : int = 1) -> str:
             CONFIG['TQDM'].update()
             time.sleep(CONFIG['POST_DOWNLOAD_WAIT'])
 
-def download_file(_url : str, _track_info : dict = None, _attempt : int = 1) -> None:
+def download_file(_url : str, _track_info : dict = None, _attempt : int = 1) -> str:
+    """Return a string representing the absolute path to the file being downloaded"""
     try:
         with requests.get(
                 _url,

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -199,14 +199,13 @@ def main() -> int:
     CONFIG['TQDM'] = tqdm(links, unit = 'album')
     if args.parallel_downloads > 1:
         with ThreadPoolExecutor(max_workers = args.parallel_downloads) as executor:
-            downloaded_zips = list(executor.map(download_album, links))
+            downloaded_zips = [file_path for file_path in list(executor.map(download_album, links)) if _is_zip(file_path)]
     else:
         for link in links:
-            zip_file = download_album(link)
-            if zip_file:
-                downloaded_zips.append(zip_file)
+            file_path = download_album(link)
+            if _is_zip(file_path):
+                downloaded_zips.append(file_path)
     CONFIG['TQDM'].close()
-    downloaded_zips = [zip_file for zip_file in downloaded_zips if zip_file]
     print(downloaded_zips)
     if args.extract:
         for zip in downloaded_zips:
@@ -454,6 +453,11 @@ def get_cookies():
         return func(domain_name = 'bandcamp.com')
     except AttributeError:
         raise Exception('Browser type [{}] is unknown. Can\'t pull cookies, so can\'t authenticate with bandcamp.'.format(CONFIG['BROWSER']))
+
+def _is_zip(file_path: str) -> bool:
+    # Determine if the file is a compressed .zip archive
+    return file_path.endswith('.zip')
+
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
Fix an unintended behaviour where when downloading a single file that is represented as an .mp3, `--extract` attempts to unzip the audio file.