### PR TITLE
Better size checking + download fixes

### DIFF
--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -524,8 +524,11 @@ def sanitize_value(_value : any) -> any:
     return _value
 
 def extension_from_url(_url : str) -> str:
-    filename = _url.split('/')[-1]
-    return os.path.splitext(filename)[1]
+    path = urllib.parse.urlparse(_url).path
+
+    filename = path.split('/')[-1]
+    if '.' not in filename: return ''
+    return path[path.rindex('.'):]
 
 def extension_from_type(_download_type : str, _format : str) -> str:
     if _download_type == "a": return ".zip"

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -433,8 +433,8 @@ def download_and_log_album(_album : dict):
     except Exception as e:
          band_name = _album.get('band_name', '')
          title = _album.get('item_title', '')
-         print_exception(e, 'Trying to download album [{}] with artist [{}] and title [{}]:').format(
-             key_for_item(_album), band_name, title)
+         print_exception(e, 'Trying to download album [{}] with artist [{}] and title [{}]:'.format(
+             key_for_item(_album), band_name, title))
     CONFIG['TQDM'].update()
     time.sleep(CONFIG['POST_DOWNLOAD_WAIT'])
 

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -416,7 +416,7 @@ def pagedata_with_retry(_url : str) -> dict:
         try:
             data = pagedata_for_url(_url)
             if data: return data
-            if CONFIG['VERBOSE'] >= 2: CONFIG['TQDM'].write('WARN: no pagedata found fetching album url [{}] (you may be rate-limited, try increasing --wait-after-download or --retry-wait)'.format(_url))
+            if CONFIG['VERBOSE']: CONFIG['TQDM'].write('WARN: no pagedata found fetching album url [{}] (you may be rate-limited, try increasing --wait-after-download or --retry-wait)'.format(_url))
         except IOError as e:
             if CONFIG['VERBOSE'] >=2: CONFIG['TQDM'].write('WARN: I/O Error on attempt # [{}] to download the page data at [{}].'.format(attempt, _url))
         except Exception as e:

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -226,41 +226,6 @@ def main() -> int:
 
     return 0
 
-# Returns true if the item's purchase time is no earlier than the given
-# cutoff, or if the item's purchase time can't be found.
-def purchase_time_ok(_item : dict, _since : datetime.datetime) -> bool:
-    # If there's no purchased field we have to say yes since we can't
-    # reliably exclude this item.
-    if 'purchased' not in _item: return True
-
-    # If there is a purchased field, compare it to the given cutoff.
-    purchaseTime = datetime.datetime.strptime(_item['purchased'], '%d %b %Y %H:%M:%S GMT')
-    return purchaseTime >= _since
-
-# Returns true if a valid item key can be assembled from the given item dict.
-def item_has_key(_item) -> bool:
-    return 'sale_item_type' in _item and 'sale_item_id' in _item
-
-# Returns the canonical key for an item (within the bandcamp API),
-# its type followed by its item id.
-def key_for_item(_item) -> str:
-    return str(_item['sale_item_type']) + str(_item['sale_item_id'])
-
-# Merges the 'redownload_urls' dict into the 'items' dict from the bandcamp
-# item list. The result is a dict keyed by key_for_item(item), where each
-# item has the added key 'redownload_url'.
-# Items with mismatched keys or no redownload url are dropped.
-def merge_items_and_urls(_items : list, _urls : dict) -> dict:
-    results = {}
-    for item in _items:
-        if not item_has_key(item) or key_for_item(item) not in _urls:
-            continue
-        key = key_for_item(item)
-        new_item = dict(item)
-        new_item['redownload_url'] = _urls[key]
-        results[key] = new_item
-    return results
-
 # Fetch item data for the given user via the bandcamp API, then return the
 # 'items' subobject, with 'redownload_url' and 'filename' fields added to each.
 def fetch_items(_hidden : bool, _user_id : str, _last_token : str, _count : int) -> dict:
@@ -339,6 +304,41 @@ def get_items_for_user(_user : str, _include_hidden : bool) -> dict:
     add_item_file_paths(items)
     
     return items
+
+# Returns true if the item's purchase time is no earlier than the given
+# cutoff, or if the item's purchase time can't be found.
+def purchase_time_ok(_item : dict, _since : datetime.datetime) -> bool:
+    # If there's no purchased field we have to say yes since we can't
+    # reliably exclude this item.
+    if 'purchased' not in _item: return True
+
+    # If there is a purchased field, compare it to the given cutoff.
+    purchaseTime = datetime.datetime.strptime(_item['purchased'], '%d %b %Y %H:%M:%S GMT')
+    return purchaseTime >= _since
+
+# Returns true if a valid item key can be assembled from the given item dict.
+def item_has_key(_item) -> bool:
+    return 'sale_item_type' in _item and 'sale_item_id' in _item
+
+# Returns the canonical key for an item (within the bandcamp API),
+# its type followed by its item id.
+def key_for_item(_item) -> str:
+    return str(_item['sale_item_type']) + str(_item['sale_item_id'])
+
+# Merges the 'redownload_urls' dict into the 'items' dict from the bandcamp
+# item list. The result is a dict keyed by key_for_item(item), where each
+# item has the added key 'redownload_url'.
+# Items with mismatched keys or no redownload url are dropped.
+def merge_items_and_urls(_items : list, _urls : dict) -> dict:
+    results = {}
+    for item in _items:
+        if not item_has_key(item) or key_for_item(item) not in _urls:
+            continue
+        key = key_for_item(item)
+        new_item = dict(item)
+        new_item['redownload_url'] = _urls[key]
+        results[key] = new_item
+    return results
 
 # Given a dictionary of bandcamp items, calculates their download path based
 # on the configured format, appends the item key if two names collide, and

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -60,6 +60,11 @@ SUPPORTED_BROWSERS = [
     'opera',
     'edge'
 ]
+TRACK_INFO_KEYS = [
+    'item_id',
+    'artist',
+    'title'
+]
 
 def main() -> int:
     parser = argparse.ArgumentParser(description = 'Download your collection from bandcamp. Requires a logged in session in a supported browser so that the browser cookies can be used to authenticate with bandcamp. Albums are saved into directories named after their artist. Already existing albums will have their file size compared to what is expected and re-downloaded if the sizes differ. Otherwise already existing albums will not be re-downloaded.')
@@ -286,13 +291,8 @@ def pagedata_for_url(_url : str) -> dict:
         parse_only = SoupStrainer('div', id='pagedata'),
     )
     div = soup.find('div')
-    if not div:
-        print(text)
-        return {}
-    result = json.loads(html.unescape(div.get('data-blob')))
-    if not result:
-        print(text)
-    return result
+    if not div: return {}
+    return json.loads(html.unescape(div.get('data-blob')))
 
 # Returns a dictionary mapping item key to item. In addition to the basic
 # bandcamp API item dict, returned items have their redownload url in
@@ -363,10 +363,10 @@ def add_item_file_paths(_items : dict):
     # Now rescan to apply final (deduped) paths.
     for key,item in _items.items():
         filename = filenames[key]
-        if filename_counts[item['raw_filename']] > 1:
+        if filename_counts[filename] > 1:
             # This filename is not unique, append the (globally unique) item
             # key so their downloads don't overwrite each other.
-            filename = item['raw_filename'] + '-' + key
+            filename = filename + '-' + key
         item['file_path'] = os.path.join(CONFIG['OUTPUT_DIR'], filename)
 
 # Check if a file already exists at the given path that matches the given

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -206,9 +206,9 @@ def main() -> int:
     CONFIG['TQDM'] = tqdm(items, unit = 'album')
     if args.parallel_downloads > 1:
         with ThreadPoolExecutor(max_workers = args.parallel_downloads) as executor:
-            downloaded_zips = [file_path for file_path in list(executor.map(download_album, items)) if _is_zip(file_path)]
+            downloaded_zips = [file_path for file_path in list(executor.map(download_album, items.values())) if _is_zip(file_path)]
     else:
-        for album in items:
+        for album in items.values():
             file_path = download_album(album)
             if _is_zip(file_path):
                 downloaded_zips.append(file_path)

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -416,6 +416,7 @@ def pagedata_with_retry(_url : str) -> dict:
         try:
             data = pagedata_for_url(_url)
             if data: return data
+            if CONFIG['VERBOSE'] >= 2: CONFIG['TQDM'].write('WARN: no pagedata found fetching album url [{}] (you may be rate-limited, try increasing --wait-after-download or --retry-wait)'.format(_url))
         except IOError as e:
             if CONFIG['VERBOSE'] >=2: CONFIG['TQDM'].write('WARN: I/O Error on attempt # [{}] to download the page data at [{}].'.format(attempt, _url))
         except Exception as e:


### PR DESCRIPTION
The main functional change for this PR is to check the download size using the album's pagedata instead of initiating a full download of the desired format, which is much faster on the client-side and much kinder to bandcamp's network on the server side. This required calculating more metadata via the initial API calls rather than waiting until `download_file`.

That change revealed some issues in the retry behavior when album pagedata is rate-limited (the new code was getting rate-limited without ever making a `download_file` call). Retry logic has been reorganized to support that case too.

This also fixes the issue of multiple downloads having the same file path. (This is possible even with a seemingly reasonable output pattern like `{artist}/{title}/{artist} - {title}` -- in my library it happened once, and it made the downloads fail every time.) Previously I've solved this by adding `{item_id}` to the pattern, but with this change the initial pattern works, and the item key will be appended only to the specific albums that have a collision instead of the entire library. (This also required calculating metadata earlier in the process.)

Related cleanup: separated helper function logic between functions that fetch metadata and functions that filter / process it, instead of duplicating filter logic for different item sources.