### PR TITLE
feat: Add dockerfile, docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Build stage
+FROM python:3.13-alpine AS builder
+
+RUN apk add --no-cache \
+    gcc \
+    musl-dev \
+    curl \
+    unzip
+
+# Install poetry
+RUN pip install poetry
+
+# Set working directory
+WORKDIR /app
+
+# Copy the project files
+COPY . .
+
+# Install dependencies using poetry
+RUN poetry config virtualenvs.create false && \
+    poetry install --only main --no-interaction --no-ansi
+
+# Final stage
+FROM python:3.13-alpine
+
+WORKDIR /app
+
+# Copy only the necessary files from builder
+COPY --from=builder /app /app
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+
+# Create a directory for downloads
+RUN mkdir /downloads
+
+# Set the entrypoint
+ENTRYPOINT ["python", "bandcamp-downloader.py"]
+
+# Set default command (can be overridden)
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,29 @@ or directly through `poetry run`:
 poetry run python bandcamp-downloader.py [arguments]
 ```
 
+## Docker
+
+1. Build the docker image  
+```
+docker build -t bandcamp-downloader .
+```
+
+2. Create a `cookies.txt` file with your bandcamp cookies (must include header). Example:
+```
+# Netscape HTTP Cookie File
+.bandcamp.com	TRUE	/	FALSE	1735689600	identity	[VALUE OF IDENTITY COOKIE]
+```
+
+3. Run the docker image
+```
+docker run --rm -it -v ./downloads/:/downloads/ -v "$(pwd)"/cookies.txt:/app/cookies.txt bandcamp-downloader -c /app/cookies.txt -d /downloads/ [USERNAME]
+```
+
+Docker Compose
+```
+docker compose run --rm bandcamp-downloader -d /downloads/ -f flac -c /app/cookies.txt [USERNAME]
+```
+
 ## Usage
 ```
 usage: bandcamp-downloader.py [-h]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  bandcamp-downloader:
+    build: .
+    image: bandcamp-downloader:latest
+    volumes:
+      - ./downloads:/downloads
+      - ./cookies.txt:/app/cookies.txt
+    command: -c /app/cookies.txt -d /downloads/flac -f flac [BANDCAMP_USERNAME]
+
+  # Example if you wanted to have docker compose download two different formats
+  # bandcamp-mp3:
+  #   image: bandcamp-downloader:latest
+  #   network_mode: none
+  #   volumes:
+  #     - ./downloads:/downloads
+  #     - ./cookies.txt:/app/cookies.txt
+  #   command: -c /app/cookies.txt -d /downloads/mp3v0 -f mp3-v0 [BANDCAMP_USERNAME] 


### PR DESCRIPTION
I wanted to set this up to run on my NAS, so I put it in docker. Tested it with downloading a couple different formats as well as `--extract`, and everything works well.

The dockerfile is currently setup to build from the git repo dir, I used a multistage builder to make the final image smaller. This could be setup with Github Actions to create a docker image for the Github repo too.

Added a docker-compose file to simplify running it in automation.

Also added usage of this docker setup to the docs.

Thanks!