### PR TITLE
feat: download-until as additional purchased filter + minor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bandcamp_downloader.egg-info/
 build/
+loaded/**

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#83afbb",
+        "activityBar.background": "#83afbb",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#f4eaf2",
+        "activityBarBadge.foreground": "#15202b",
+        "commandCenter.border": "#15202b99",
+        "titleBar.activeBackground": "#629aa9",
+        "titleBar.activeForeground": "#15202b",
+        "titleBar.inactiveBackground": "#629aa999",
+        "titleBar.inactiveForeground": "#15202b99"
+    },
+    "peacock.color": "629aa9"
+}

--- a/bandcamp-downloader.py
+++ b/bandcamp-downloader.py
@@ -83,7 +83,7 @@ def main() -> int:
     )
     parser.add_argument(
         '--directory', '-d',
-        default = os.getcwd(),
+        default = f"{os.getcwd()}/loaded/",
         help='The directory to download albums to. Defaults to the current directory.'
     )
     parser.add_argument(


### PR DESCRIPTION
- [x] handling of upper exclusive download-until arg
- [x] exception handling for nulled values
- [x] defaulting to `loaded` directory in root, to help with root dir getting spammed by download folders etc.
- [x] misc: peacock setting for the repo if used in vscode
- [x] tested multiple date cases on my local machine, all as expected
